### PR TITLE
Use longer form of the YAML file extension for workflow files

### DIFF
--- a/sdk/github.md
+++ b/sdk/github.md
@@ -78,7 +78,7 @@ The reality is that an Action is _just_ a component of this technology stack, a 
 
 This is the name of the file within the `.github/workflows` folder.
 
-- Will always have a `yml` extension
+- Should have a `yaml` extension
 - Should use one of our standard names unless they’re not suited. Standard names and their purposes are as follows:
   - `assemble`:
     - build the project (archives / artifacts)


### PR DESCRIPTION
I think this'll add clarity.

Currently we have a mix of `yml` and `yaml`. This inconsistency is ugly, but also it could end up with the same file name being used to create two instances with different extensions.