### PR TITLE
SDK: Product Lifecycle refinement, including titles for GitHub releases

### DIFF
--- a/sdk/product-lifecycle.md
+++ b/sdk/product-lifecycle.md
@@ -12,7 +12,7 @@ The Pre-Release `<build>` component should always be a positive integer value.
 
 **Experimental features we do not support but may be evolved or removed depending on demand.**
 
-## Alpha or Technical Preview
+### Alpha or Technical Preview
 
 **Alpha products are for early testing and validation by a small and limited group of customers.**
 

--- a/sdk/product-lifecycle.md
+++ b/sdk/product-lifecycle.md
@@ -4,7 +4,9 @@ Two preliminary lifecycle stages - Alpha and Beta - are designed to ensure that 
 
 See [Semantic Versioning (SemVer)](https://semver.org/) in respect of the terminology used in this document, specifically "Pre-Release Version Suffix".
 
-## Labs
+## Pre-Releases
+
+### Labs
 
 **Experimental features we do not support but may be evolved or removed depending on demand.**
 
@@ -18,7 +20,7 @@ No SLAs apply to Alpha releases. We strongly recommend using Alpha software feat
 
 **Pre-Release Version Suffix:** `-alpha.x`
 
-## Beta
+### Beta
 
 **Beta products are made publicly available for testing piloting by a broader group of customers.**
 
@@ -28,7 +30,7 @@ Customers using the beta version should be aware that some outstanding issues ma
 
 **Pre-Release Version Suffix:** `-beta.x`
 
-## Release Candidate
+### Release Candidate
 
 **Release candidate product is supposed to be fully functional with a minimum number of  known issues and ready to be released after internal testing.**
 

--- a/sdk/product-lifecycle.md
+++ b/sdk/product-lifecycle.md
@@ -4,9 +4,9 @@ Two preliminary lifecycle stages - Alpha and Beta - are designed to ensure that 
 
 See [Semantic Versioning (SemVer)](https://semver.org/) in respect of the terminology used in this document, specifically "Pre-Release Version Suffix".
 
-The Pre-Release `<build>` component should always be a positive integer value.
-
 ## Pre-Releases
+
+The Pre-Release `<build>` component should always be a positive integer value.
 
 ### Labs
 

--- a/sdk/product-lifecycle.md
+++ b/sdk/product-lifecycle.md
@@ -4,6 +4,8 @@ Two preliminary lifecycle stages - Alpha and Beta - are designed to ensure that 
 
 See [Semantic Versioning (SemVer)](https://semver.org/) in respect of the terminology used in this document, specifically "Pre-Release Version Suffix".
 
+The Pre-Release `<build>` component should always be a positive integer value.
+
 ## Pre-Releases
 
 ### Labs
@@ -18,7 +20,9 @@ These products will be Demo-able, work end-to-end but have limitations in functi
 
 No SLAs apply to Alpha releases. We strongly recommend using Alpha software features in test environments only to avoid introducing risk to production deployments because we can’t guarantee that Alpha product works as specified and from build to build some breaking changes may be introduced.  
 
-**Pre-Release Version Suffix:** `-alpha.x`
+**Pre-Release Version Suffix:** `-alpha.<build>`
+
+**GitHub Release Title format:** `<major>.<minor>.<patch>, Alpha <build>`
 
 ### Beta
 
@@ -28,7 +32,9 @@ Beta releases are _more_ feature complete and stable than Alpha releases, close 
 
 Customers using the beta version should be aware that some outstanding issues may be present and consistency of interfaces are not guaranteed (i.e. behaviors and APIs may still change). Documentation will be present, but will evolve as the Engineering team addresses bugs and makes improvements in anticipation of Release.
 
-**Pre-Release Version Suffix:** `-beta.x`
+**Pre-Release Version Suffix:** `-beta.<build>`
+
+**GitHub Release Title format:** `<major>.<minor>.<patch>, Beta <build>`
 
 ### Release Candidate
 
@@ -38,7 +44,9 @@ This version is fully feature complete and stable, will not be changed in terms 
 
 Release Candidate may be a subject to SLAs in some cases.
 
-**Pre-Release Version Suffix:** `-rc.x`
+**Pre-Release Version Suffix:** `-rc.<build>`
+
+**GitHub Release Title format:** `<major>.<minor>.<patch>, Release Candidate <build>`
 
 ## General Availability (Release)
 


### PR DESCRIPTION
This came up when discussing [the title for the `v1.1.0-rc.1` release of Ably Asset Tracking for Android](https://github.com/ably/ably-asset-tracking-android/releases/tag/v1.1.0-rc.1) with @KacperKluka.