### PR TITLE
SDK Team Guidance around Releases

### DIFF
--- a/sdk/README.md
+++ b/sdk/README.md
@@ -10,3 +10,4 @@
 | [GitHub](github.md) | Our efforts to conform the way we use GitHub across our open source repositories. |
 | [Product Lifecycle](product-lifecycle.md) | Defines stages of product maturity, including Labs, Alpha, Beta, RC, GA and EOL. |
 | [Pull Requests](pull-requests.md) | Guidance for how we approach PRs. |
+| [Releases](releases.md) | Our ideal release process, including publishing workflows. |

--- a/sdk/releases.md
+++ b/sdk/releases.md
@@ -22,7 +22,7 @@ Where technically possible, SDK repository release processes which claim to adhe
 
 - Branch from the `main` branch
 - Merge to the `main` branch, once approved
-- Named liked `release/<version>`
+- Named like `release/<version>`
 - Increment the version
 - Version should conform to [SemVer](https://semver.org/)
 - Add change log entry

--- a/sdk/releases.md
+++ b/sdk/releases.md
@@ -30,7 +30,7 @@ Where technically possible, SDK repository release processes which claim to adhe
 ## Publish Workflow
 
 - Run in GitHub environment
-- Be manually triggered using a [`workflow_dispatch` event](https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#workflow_dispatch)
+- Be written so that it is manually triggered using a [`workflow_dispatch` event](https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#workflow_dispatch)
 - Override the default [checkout](https://github.com/actions/checkout) `ref` with a commit SHA supplied as in input to the triggering event, where that SHA will generally be `HEAD` of the `main` branch, at the point the [Release Branch](#release-branch) was merged
 - Publish to downstream package repositories using an Ably identity, not using an identity tied to an individual person in any way
 - Use GitHub repository secrets or ideally [GitHub OIDC](https://docs.github.com/en/actions/deployment/security-hardening-your-deployments/about-security-hardening-with-openid-connect) (ask [@lmars](https://github.com/lmars)), to securely manage the flow of credentials required to publish under the Ably identity

--- a/sdk/releases.md
+++ b/sdk/releases.md
@@ -1,0 +1,34 @@
+# Ably SDK Team: Guidance on Releases
+
+This document outlines our ideal requirements for SDK releases.
+
+There will be some SDK repositories:
+
+- which are yet to have the work done on them which will implement this
+- where it's necessary to deviate from some of the ideals specified here due to constraints which are innate or otherwise idiomatic to the platform being released for
+
+Where technically possible, SDK repository release processes which claim to adhere to this guidance must follow these ideal requirements closely.
+
+## Release Process
+
+1. Merge all pull requests containing changes intended for this release to `main` branch
+2. Prepare a [Release Branch](#release-branch) and a corresponding pull request, obtain approval from reviewers and then merge to `main` branch
+3. Trigger the [Publish Workflow](#publish-workflow)
+4. If the publish fails then add commits to the `main` branch that aim to fix the problem and then try step 3 again
+5. Push Git version tag, which may or may not have a `v` prefix according to the existing conventions for this SDK repository
+6. Create GitHub release
+
+## Release Branch
+
+- Branch from the `main` branch
+- Merge to the `main` branch, once approved
+- Named liked `release/<version>`
+- Increment the version
+- Version should conform to [SemVer](https://semver.org/)
+- Add change log entry
+
+## Publish Workflow
+
+- Run in GitHub environment
+- Publish to downstream package repositories using an Ably identity, not using an identity tied to an individual person in any way
+- Use GitHub repository secrets to securely store the credentials required to publish under the Ably identity

--- a/sdk/releases.md
+++ b/sdk/releases.md
@@ -33,4 +33,4 @@ Where technically possible, SDK repository release processes which claim to adhe
 - Be manually triggered using a [`workflow_dispatch` event](https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#workflow_dispatch)
 - Override the default [checkout](https://github.com/actions/checkout) `ref` with a commit SHA supplied as in input to the triggering event, where that SHA will generally be `HEAD` of the `main` branch, at the point the [Release Branch](#release-branch) was merged
 - Publish to downstream package repositories using an Ably identity, not using an identity tied to an individual person in any way
-- Use GitHub repository secrets to securely store the credentials required to publish under the Ably identity
+- Use GitHub repository secrets or ideally [GitHub OIDC](https://docs.github.com/en/actions/deployment/security-hardening-your-deployments/about-security-hardening-with-openid-connect) (ask [@lmars](https://github.com/lmars)), to securely manage the flow of credentials required to publish under the Ably identity

--- a/sdk/releases.md
+++ b/sdk/releases.md
@@ -15,7 +15,7 @@ Where technically possible, SDK repository release processes which claim to adhe
 2. Prepare a [Release Branch](#release-branch) and a corresponding pull request, obtain approval from reviewers and then merge to `main` branch
 3. Trigger the [Publish Workflow](#publish-workflow)
 4. If the publish fails then fix the state of the `main` branch, via one or more approved pull requests, with focussed changes that aim to fix the problem and then try step 3 again
-5. Push Git version tag, which may or may not have a `v` prefix according to the existing conventions for this SDK repository
+5. Push Git [Version Tag](#version-tag)
 6. Create GitHub release
 
 ## Release Branch
@@ -34,3 +34,24 @@ Where technically possible, SDK repository release processes which claim to adhe
 - Override the default [checkout](https://github.com/actions/checkout) `ref` with a commit SHA supplied as in input to the triggering event, where that SHA will generally be `HEAD` of the `main` branch, at the point the [Release Branch](#release-branch) was merged
 - Publish to downstream package repositories using an Ably identity, not using an identity tied to an individual person in any way
 - Use GitHub repository secrets or ideally [GitHub OIDC](https://docs.github.com/en/actions/deployment/security-hardening-your-deployments/about-security-hardening-with-openid-connect) (ask [@lmars](https://github.com/lmars)), to securely manage the flow of credentials required to publish under the Ably identity
+
+## Version Tag
+
+Should:
+
+- have a `v` prefix - e.g. `v1.2.3` for the release of version `1.2.3`
+- be pushed after the release has been published to downstream package repositories
+- be made against the commit against which the [Publish Workflow](#publish-workflow) was successfully run
+- not be subsequently moved
+
+Additional Notes:
+
+- This guidance relates to the fully qualified, [semantically versioned](https://semver.org/) tags that represent a specific release,
+  which is why these tags should not be subsequently moved once they have been pushed.
+  There are conventions around additional, moveable tags tracking major (e.g. `v1`) and minor (e.g. `v1.2`) releases which are used by some ecosystems (e.g. [GitHub Actions](https://docs.github.com/en/actions/creating-actions/releasing-and-maintaining-actions)), but we don't use those conventions or moveable tags for our SDK releases, therefore they're not in scope of this document.
+- For historical reasons, we have some SDK repositories which have version tags that do not have the `v` prefix.
+  Where possible, these repositories should be migrated to conform to the format specified here, including the `v` prefix.
+  Any such migration should:
+  - leave existing tags where they are
+  - add new tags, aligned to the same commit as the existing tags, with the `v` prefix
+  - update release procedures and any related tooling to make it clear that the `v` prefix is required

--- a/sdk/releases.md
+++ b/sdk/releases.md
@@ -25,7 +25,7 @@ Where technically possible, SDK repository release processes which claim to adhe
 - Named like `release/<version>`
 - Increment the version
 - Version should conform to [SemVer](https://semver.org/)
-- Add change log entry
+- Add change log entry (process to be documented under [#17](https://github.com/ably/engineering/issues/17))
 
 ## Publish Workflow
 

--- a/sdk/releases.md
+++ b/sdk/releases.md
@@ -30,5 +30,7 @@ Where technically possible, SDK repository release processes which claim to adhe
 ## Publish Workflow
 
 - Run in GitHub environment
+- Be manually triggered using a [`workflow_dispatch` event](https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#workflow_dispatch)
+- Override the default [checkout](https://github.com/actions/checkout) `ref` with a commit SHA supplied as in input to the triggering event, where that SHA will generally be `HEAD` of the `main` branch, at the point the [Release Branch](#release-branch) was merged
 - Publish to downstream package repositories using an Ably identity, not using an identity tied to an individual person in any way
 - Use GitHub repository secrets to securely store the credentials required to publish under the Ably identity

--- a/sdk/releases.md
+++ b/sdk/releases.md
@@ -20,20 +20,23 @@ Where technically possible, SDK repository release processes which claim to adhe
 
 ## Release Branch
 
-- Branch from the `main` branch
-- Merge to the `main` branch, once approved
-- Named like `release/<version>`
-- Increment the version
-- Version should conform to [SemVer](https://semver.org/)
-- Add change log entry (process to be documented under [#17](https://github.com/ably/engineering/issues/17))
+Should:
+
+- branch from the `main` branch
+- merge to the `main` branch, once approved
+- be named like `release/<version>`
+- increment the version, conforming to [SemVer](https://semver.org/)
+- add a change log entry (process to be documented under [#17](https://github.com/ably/engineering/issues/17))
 
 ## Publish Workflow
 
-- Run in GitHub environment
-- Be written so that it is manually triggered using a [`workflow_dispatch` event](https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#workflow_dispatch)
-- Override the default [checkout](https://github.com/actions/checkout) `ref` with a commit SHA supplied as in input to the triggering event, where that SHA will generally be `HEAD` of the `main` branch, at the point the [Release Branch](#release-branch) was merged
-- Publish to downstream package repositories using an Ably identity, not using an identity tied to an individual person in any way
-- Use GitHub repository secrets or ideally [GitHub OIDC](https://docs.github.com/en/actions/deployment/security-hardening-your-deployments/about-security-hardening-with-openid-connect) (ask [@lmars](https://github.com/lmars)), to securely manage the flow of credentials required to publish under the Ably identity
+Should:
+
+- run in the GitHub environment
+- be written so that it is manually triggered using a [`workflow_dispatch` event](https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#workflow_dispatch)
+- override the default [checkout](https://github.com/actions/checkout) `ref` with a commit SHA supplied as in input to the triggering event, where that SHA will generally be `HEAD` of the `main` branch, at the point the [Release Branch](#release-branch) was merged
+- publish to downstream package repositories using an Ably identity, not using an identity tied to an individual person in any way
+- use GitHub repository secrets or ideally [GitHub OIDC](https://docs.github.com/en/actions/deployment/security-hardening-your-deployments/about-security-hardening-with-openid-connect) (ask [@lmars](https://github.com/lmars)), to securely manage the flow of credentials required to publish under the Ably identity
 
 ## Version Tag
 

--- a/sdk/releases.md
+++ b/sdk/releases.md
@@ -14,7 +14,7 @@ Where technically possible, SDK repository release processes which claim to adhe
 1. Merge all pull requests containing changes intended for this release to `main` branch
 2. Prepare a [Release Branch](#release-branch) and a corresponding pull request, obtain approval from reviewers and then merge to `main` branch
 3. Trigger the [Publish Workflow](#publish-workflow)
-4. If the publish fails then add commits to the `main` branch that aim to fix the problem and then try step 3 again
+4. If the publish fails then fix the state of the `main` branch, via one or more approved pull requests, with focussed changes that aim to fix the problem and then try step 3 again
 5. Push Git version tag, which may or may not have a `v` prefix according to the existing conventions for this SDK repository
 6. Create GitHub release
 

--- a/sdk/releases.md
+++ b/sdk/releases.md
@@ -34,7 +34,7 @@ Should:
 
 - run in the GitHub environment
 - be written so that it is manually triggered using a [`workflow_dispatch` event](https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#workflow_dispatch)
-- override the default [checkout](https://github.com/actions/checkout) `ref` with a commit SHA supplied as in input to the triggering event, where that SHA will generally be `HEAD` of the `main` branch, at the point the [Release Branch](#release-branch) was merged
+- override the default [checkout](https://github.com/actions/checkout) `ref` with a commit SHA supplied as an input to the triggering event, where that SHA will generally be `HEAD` of the `main` branch, at the point the [Release Branch](#release-branch) was merged
 - publish to downstream package repositories using an Ably identity, not using an identity tied to an individual person in any way
 - use GitHub repository secrets or ideally [GitHub OIDC](https://docs.github.com/en/actions/deployment/security-hardening-your-deployments/about-security-hardening-with-openid-connect) (ask [@lmars](https://github.com/lmars)), to securely manage the flow of credentials required to publish under the Ably identity
 


### PR DESCRIPTION
While we're working on moving more of our SDK repository release processes to execute 'from the cloud', it's become clear that we need a clear template for how this should ideally be done.

The process outlined in this template needs to accommodate the way that we like to work in the SDK Team at Ably. This is just a proposal and, therefore, it is open and expected to change as the views of team members come in. We also expect this first iteration of this template to evolve over time as we learn more about how we like to do releases or technologies change which require us to change our stance.

Creation of this document was triggered by [this comment](https://github.com/ably/ably-js/issues/805#issuecomment-1067856291), by @jamienewcomb, asking for acceptance criteria for `ably-js` when implementing 'Continuous Delivery via GitHub workflow'.

While this pull request remains open, the rendered output can be previewed [on the underlying branch](https://github.com/ably/engineering/blob/sdk-releases/sdk/releases.md).