### PR TITLE
Update to number of approvals required on PRs

### DIFF
--- a/sdk/pull-requests.md
+++ b/sdk/pull-requests.md
@@ -10,7 +10,7 @@ This document is intended as a canonical reference documenting how the SDK Team 
 
 ## General
 
-- All PRs should be approved by at least two SDK Team members, where at least one of them actively maintains that client library
+- All PRs should be approved by at least one person who actively maintains that client library
 - Ideally, in most cases, PRs should be landed (merged) to the `main` branch by the Lead Engineer responsible for that client library
 - Avoid publishing comments into that public domain that just represent housekeeping or reminders to other team members - these should more appropriately be handled as internal messaging over Slack (probably via the appropriate SDK repository channel)
 


### PR DESCRIPTION
On the back of a discussion with the SDK team, it was agreed that we will now ask for at least 1 approver before merging