### PR TITLE
Suggest number of reviewers based on change complexity

### DIFF
--- a/sdk/pull-requests.md
+++ b/sdk/pull-requests.md
@@ -14,6 +14,20 @@ This document is intended as a canonical reference documenting how the SDK Team 
 - Ideally, in most cases, PRs should be landed (merged) to the `main` branch by the Lead Engineer responsible for that client library
 - Avoid publishing comments into that public domain that just represent housekeeping or reminders to other team members - these should more appropriately be handled as internal messaging over Slack (probably via the appropriate SDK repository channel)
 
+### Considerations when adding reviewers
+Enforced number of approvals is based on that PR contains trivial changes. On any instance of a non-trivial change approval of more than one reviewer should be seeked. 
+While 'trivial changes' is a subjective matter, developers should use their own judgements. Some examples of trivial changes are:
+- Comment changes.
+- Non public function / class / variable renames.
+- Code formattings. 
+- A string literal, an error code where the change is well documented. Such as in a feature spec document.
+
+Any other changes to the code will benefit from reviews from more than one person. In some instances the number of reviewers should be increased. Some examples of such changes are:
+- Public API change.
+- Library struture changes. New modules, extensions, splits etc.
+- A change on a core algorithm. For example the way the library handles message queueing.  
+- An important architectural change. Internal communication architecture, message flow architecture, etc.
+
 ## Etiquette
 
 ### Conversations

--- a/sdk/pull-requests.md
+++ b/sdk/pull-requests.md
@@ -34,10 +34,10 @@ Any other changes to the code will benefit from reviews from more than one perso
 
 In some instances the number of reviewers should be increased to more than two people. Some examples of such changes are:
 
-- Public API change.
-- Library struture changes. New modules, extensions, splits etc.
-- A change on a core algorithm. For example the way the library handles message queueing.  
-- An important architectural change. Internal communication architecture, message flow architecture, etc.
+- Public API change
+- Library struture changes - such as new modules, extensions, splits, etc.
+- A change on a core algorithm - for example the way the library handles message queueing
+- An important architectural change - such as internal communication architecture, message flow architecture, etc.
 
 ### Conversations
 

--- a/sdk/pull-requests.md
+++ b/sdk/pull-requests.md
@@ -35,7 +35,7 @@ Any other changes to the code will benefit from reviews from more than one perso
 In some instances the number of reviewers should be increased to more than two people. Some examples of such changes are:
 
 - Public API change
-- Library struture changes - such as new modules, extensions, splits, etc.
+- Library structure changes - such as new modules, extensions, splits, etc.
 - A change on a core algorithm - for example the way the library handles message queueing
 - An important architectural change - such as internal communication architecture, message flow architecture, etc.
 

--- a/sdk/pull-requests.md
+++ b/sdk/pull-requests.md
@@ -14,26 +14,30 @@ This document is intended as a canonical reference documenting how the SDK Team 
 - Ideally, in most cases, PRs should be landed (merged) to the `main` branch by the Lead Engineer responsible for that client library
 - Avoid publishing comments into that public domain that just represent housekeeping or reminders to other team members - these should more appropriately be handled as internal messaging over Slack (probably via the appropriate SDK repository channel)
 
-### Considerations when adding reviewers
-Enforced number of approvals is based on that PR contains trivial changes. On any instance of a non-trivial change approval of more than one reviewer should be seeked. 
+## Etiquette
+
+### Reviewer Count
+
+Enforced number of approvals is based on that PR contains trivial changes. On any instance of a non-trivial change approval of more than one reviewer should be sought.
 While 'trivial changes' is a subjective matter, developers should use their own judgements. Some examples of trivial changes are:
+
 - Comment changes.
 - Non public function / class / variable renames.
 - Code formattings. 
 - A string literal, an error code where the change is well documented. Such as in a feature spec document.
 
 Any other changes to the code will benefit from reviews from more than one person. Some example changes that are not trivial are:
+
 - Bug fixes.
 - Change, Addition or deletion of functions, classes, variables, etc. 
 - Refactorings. 
 
 In some instances the number of reviewers should be increased to more than two people. Some examples of such changes are:
+
 - Public API change.
 - Library struture changes. New modules, extensions, splits etc.
 - A change on a core algorithm. For example the way the library handles message queueing.  
 - An important architectural change. Internal communication architecture, message flow architecture, etc.
-
-## Etiquette
 
 ### Conversations
 

--- a/sdk/pull-requests.md
+++ b/sdk/pull-requests.md
@@ -22,7 +22,12 @@ While 'trivial changes' is a subjective matter, developers should use their own 
 - Code formattings. 
 - A string literal, an error code where the change is well documented. Such as in a feature spec document.
 
-Any other changes to the code will benefit from reviews from more than one person. In some instances the number of reviewers should be increased. Some examples of such changes are:
+Any other changes to the code will benefit from reviews from more than one person. Some example changes that are not trivial are:
+- Bug fixes.
+- Change, Addition or deletion of functions, classes, variables, etc. 
+- Refactorings. 
+
+In some instances the number of reviewers should be increased to more than two people. Some examples of such changes are:
 - Public API change.
 - Library struture changes. New modules, extensions, splits etc.
 - A change on a core algorithm. For example the way the library handles message queueing.  

--- a/sdk/pull-requests.md
+++ b/sdk/pull-requests.md
@@ -21,16 +21,16 @@ This document is intended as a canonical reference documenting how the SDK Team 
 Enforced number of approvals is based on that PR contains trivial changes. On any instance of a non-trivial change approval of more than one reviewer should be sought.
 While 'trivial changes' is a subjective matter, developers should use their own judgements. Some examples of trivial changes are:
 
-- Comment changes.
-- Non public function / class / variable renames.
-- Code formattings. 
-- A string literal, an error code where the change is well documented. Such as in a feature spec document.
+- Comment changes
+- Non public function / class / variable renames
+- Code formattings
+- A string literal, an error code where the change is well documented - such as in a feature spec document
 
 Any other changes to the code will benefit from reviews from more than one person. Some example changes that are not trivial are:
 
-- Bug fixes.
-- Change, Addition or deletion of functions, classes, variables, etc. 
-- Refactorings. 
+- Bug fixes
+- Change, Addition or deletion of functions, classes, variables, etc
+- Refactorings
 
 In some instances the number of reviewers should be increased to more than two people. Some examples of such changes are:
 


### PR DESCRIPTION
As a follow up to https://github.com/ably/engineering/issues/29

I added some suggestions on which instances to seek one, two or more reviewers.

Closes https://github.com/ably/engineering/issues/29