### PR TITLE
Define our set of GitHub labels for open source SDK repositories

### DIFF
--- a/.markdownlint-cli2.yaml
+++ b/.markdownlint-cli2.yaml
@@ -6,5 +6,8 @@ config:
   # This prevents use of "..." and "!" at the end of headings, where they are useful and expressive.
   no-trailing-punctuation: false
 
-  # In our GitHub First context, it's very normal to include GitHub issue URLs 'bare' so GitHub formats them nicely for us
+  # In our GitHub First context, it's very normal to include GitHub issue URLs 'bare' so GitHub formats them nicely for us.
   no-bare-urls: false
+
+  # The odd splash of 'raw' HTML in our markdown allows us to be more expressive (e.g. spans with coloured background).
+  no-inline-html: false

--- a/.markdownlint-cli2.yaml
+++ b/.markdownlint-cli2.yaml
@@ -8,6 +8,3 @@ config:
 
   # In our GitHub First context, it's very normal to include GitHub issue URLs 'bare' so GitHub formats them nicely for us.
   no-bare-urls: false
-
-  # The odd splash of 'raw' HTML in our markdown allows us to be more expressive (e.g. spans with coloured background).
-  no-inline-html: false

--- a/sdk/github.md
+++ b/sdk/github.md
@@ -205,8 +205,24 @@ tied in with the [SDK Upload Action](https://github.com/ably/sdk-upload-action).
 
 ## Labels
 
-We are slowly converging on a set of labels that are useful for our context and these are being duplicated across client libraries when needed.
-This list is canonically defined [here](https://github.com/ably/ably-common/blob/main/github/labels.yml).
+The following table canonically defines labels we use in common across our open source SDK repositories:
+
+| Name | Color | Description | Additional Notes |
+| ---- | ----------- | ----- | ---------------- |
+| <span style="padding: 0.25em 0.75em; border-radius: 1em; font-weight: 500; white-space: nowrap; background-color: #fbca04; color: black;">blocked-by-ably</span> | `fbca04` | We can't proceed until something under our direct control, in a different codebase, happens. | Comments should be added to indicate what the blockage is (e.g. another SDK repository). |
+| <span style="padding: 0.25em 0.75em; border-radius: 1em; font-weight: 500; white-space: nowrap; background-color: #fbca04; color: black;">blocked-by-external</span> | `fbca04` | We can't proceed until something outside of Ably's direct control happens. | Comments should be added to indicate what the blockage is. |
+| <span style="padding: 0.25em 0.75em; border-radius: 1em; font-weight: 500; white-space: nowrap; background-color: #d73a4a; color: white;">bug</span> | `d73a4a` | Something isn't working. It's clear that this does need to be fixed. | Usually implies that related changes can be released in a `patch` version bump. |
+| <span style="padding: 0.25em 0.75em; border-radius: 1em; font-weight: 500; white-space: nowrap; background-color: #ec4b42; color: white;">breaking</span> | `ec4b42` | Affects the developer experience when working in our codebase. | Implies a need to release related changes in a `major` version bump. |
+| <span style="padding: 0.25em 0.75em; border-radius: 1em; font-weight: 500; white-space: nowrap; background-color: #ff88cc; color: black;">code-quality</span> | `ff88cc` | Affects the developer experience when working in our codebase. |
+| <span style="padding: 0.25em 0.75em; border-radius: 1em; font-weight: 500; white-space: nowrap; background-color: #0075ca; color: white;">documentation</span> | `0075ca` | Improvements or additions to public interface documentation (API reference or readme). |
+| <span style="padding: 0.25em 0.75em; border-radius: 1em; font-weight: 500; white-space: nowrap; background-color: #a2eeef; color: black;">enhancement</span> | `a2eeef` | New feature or request. | Implies a need to release related changes in a `minor` version bump. |
+| <span style="padding: 0.25em 0.75em; border-radius: 1em; font-weight: 500; white-space: nowrap; background-color: #70fc6b; color: black;">example-app</span> | `70fc6b` | Relates to the example apps included in this repository. | Not all repositories have embedded example apps. |
+| <span style="padding: 0.25em 0.75em; border-radius: 1em; font-weight: 500; white-space: nowrap; background-color: #ff8888; color: black;">failing-test</span> | `ff8888` | Where a test is failing either locally or in CI. Perhaps flakey (badly written), wrong or bug. |
+| <span style="padding: 0.25em 0.75em; border-radius: 1em; font-weight: 500; white-space: nowrap; background-color: #ff8888; color: black;">testing</span> | `ff8888` | Includes all kinds of tests, the way that we run tests and test infrastructure. |
+
+While GitHub does allow us to use mixed case and spaces in label names, we've restricted ourselves to all lowercase and dashes instead of spaces to separate words.
+
+We do not have any labels that imply or otherwise infer importance or prioritisation of issues or pull requests because that information is internally managed using Jira (see [GitHub First](#github-first)).
 
 ## Flexibility
 

--- a/sdk/github.md
+++ b/sdk/github.md
@@ -213,7 +213,7 @@ The following table canonically defines labels we use in common across our open 
 | `blocked-by-external` | ![fbca04](https://img.shields.io/badge/-fbca04-fbca04) | We can't proceed until something outside of Ably's direct control happens. | Comments should be added to indicate what the blockage is. |
 | `bug` | ![d73a4a](https://img.shields.io/badge/-d73a4a-d73a4a) | Something isn't working. It's clear that this does need to be fixed. | Usually implies that related changes can be released in a `patch` version bump. |
 | `breaking` | ![ec4b42](https://img.shields.io/badge/-ec4b42-ec4b42) | Backwards incompatible changes made to the public API. | Implies a need to release related changes in a `major` version bump. |
-| `code-quality` | ![ff88cc](https://img.shields.io/badge/-ff88cc-ff88cc) | Affects the developer experience when working in our codebase. |
+| `code-quality` | ![ff88cc](https://img.shields.io/badge/-ff88cc-ff88cc) | Affects the developer experience when working in our codebase. | Relating to the maintainabily of the codebase, not affecting the public API, therefore unlikely to be customer facing. |
 | `documentation` | ![0075ca](https://img.shields.io/badge/-0075ca-0075ca) | Improvements or additions to public interface documentation (API reference or readme). |
 | `enhancement` | ![a2eeef](https://img.shields.io/badge/-a2eeef-a2eeef) | New feature or request. | Implies a need to release related changes in a `minor` version bump. |
 | `example-app` | ![70fc6b](https://img.shields.io/badge/-70fc6b-70fc6b) | Relates to the example apps included in this repository. | Not all repositories have embedded example apps. |

--- a/sdk/github.md
+++ b/sdk/github.md
@@ -222,6 +222,8 @@ The following table canonically defines labels we use in common across our open 
 
 The _Name_, _Color_ and _Description_ values above should be used when creating the corresponding labels in repositories.
 
+It is expected that some labels will be used together - for example `enhancement` and `breaking`, indicating a feature that's been added in a way that introduces backwards incompatible changes into the public API, therefore implying the need to release in a `major` (_not_ `minor`) version bump.
+
 While GitHub does allow us to use mixed case and spaces in label names, we've restricted ourselves to all lowercase and dashes instead of spaces to separate words.
 
 We do not have any labels that imply or otherwise infer importance or prioritisation of issues or pull requests because that information is internally managed using Jira (see [GitHub First](#github-first)).

--- a/sdk/github.md
+++ b/sdk/github.md
@@ -209,16 +209,16 @@ The following table canonically defines labels we use in common across our open 
 
 | Name | Color | Description | Additional Notes |
 | ---- | ----------- | ----- | ---------------- |
-| <span style="padding: 0.25em 0.75em; border-radius: 1em; font-weight: 500; white-space: nowrap; background-color: #fbca04; color: black;">blocked-by-ably</span> | `fbca04` | We can't proceed until something under our direct control, in a different codebase, happens. | Comments should be added to indicate what the blockage is (e.g. another SDK repository). |
-| <span style="padding: 0.25em 0.75em; border-radius: 1em; font-weight: 500; white-space: nowrap; background-color: #fbca04; color: black;">blocked-by-external</span> | `fbca04` | We can't proceed until something outside of Ably's direct control happens. | Comments should be added to indicate what the blockage is. |
-| <span style="padding: 0.25em 0.75em; border-radius: 1em; font-weight: 500; white-space: nowrap; background-color: #d73a4a; color: white;">bug</span> | `d73a4a` | Something isn't working. It's clear that this does need to be fixed. | Usually implies that related changes can be released in a `patch` version bump. |
-| <span style="padding: 0.25em 0.75em; border-radius: 1em; font-weight: 500; white-space: nowrap; background-color: #ec4b42; color: white;">breaking</span> | `ec4b42` | Affects the developer experience when working in our codebase. | Implies a need to release related changes in a `major` version bump. |
-| <span style="padding: 0.25em 0.75em; border-radius: 1em; font-weight: 500; white-space: nowrap; background-color: #ff88cc; color: black;">code-quality</span> | `ff88cc` | Affects the developer experience when working in our codebase. |
-| <span style="padding: 0.25em 0.75em; border-radius: 1em; font-weight: 500; white-space: nowrap; background-color: #0075ca; color: white;">documentation</span> | `0075ca` | Improvements or additions to public interface documentation (API reference or readme). |
-| <span style="padding: 0.25em 0.75em; border-radius: 1em; font-weight: 500; white-space: nowrap; background-color: #a2eeef; color: black;">enhancement</span> | `a2eeef` | New feature or request. | Implies a need to release related changes in a `minor` version bump. |
-| <span style="padding: 0.25em 0.75em; border-radius: 1em; font-weight: 500; white-space: nowrap; background-color: #70fc6b; color: black;">example-app</span> | `70fc6b` | Relates to the example apps included in this repository. | Not all repositories have embedded example apps. |
-| <span style="padding: 0.25em 0.75em; border-radius: 1em; font-weight: 500; white-space: nowrap; background-color: #ff8888; color: black;">failing-test</span> | `ff8888` | Where a test is failing either locally or in CI. Perhaps flakey (badly written), wrong or bug. |
-| <span style="padding: 0.25em 0.75em; border-radius: 1em; font-weight: 500; white-space: nowrap; background-color: #ff8888; color: black;">testing</span> | `ff8888` | Includes all kinds of tests, the way that we run tests and test infrastructure. |
+| `blocked-by-ably` | ![fbca04](https://img.shields.io/badge/-fbca04-fbca04) | We can't proceed until something under our direct control, in a different codebase, happens. | Comments should be added to indicate what the blockage is (e.g. another SDK repository). |
+| `blocked-by-external` | ![fbca04](https://img.shields.io/badge/-fbca04-fbca04) | We can't proceed until something outside of Ably's direct control happens. | Comments should be added to indicate what the blockage is. |
+| `bug` | ![d73a4a](https://img.shields.io/badge/-d73a4a-d73a4a) | Something isn't working. It's clear that this does need to be fixed. | Usually implies that related changes can be released in a `patch` version bump. |
+| `breaking` | ![ec4b42](https://img.shields.io/badge/-ec4b42-ec4b42) | Affects the developer experience when working in our codebase. | Implies a need to release related changes in a `major` version bump. |
+| `code-quality` | ![ff88cc](https://img.shields.io/badge/-ff88cc-ff88cc) | Affects the developer experience when working in our codebase. |
+| `documentation` | ![0075ca](https://img.shields.io/badge/-0075ca-0075ca) | Improvements or additions to public interface documentation (API reference or readme). |
+| `enhancement` | ![a2eeef](https://img.shields.io/badge/-a2eeef-a2eeef) | New feature or request. | Implies a need to release related changes in a `minor` version bump. |
+| `example-app` | ![70fc6b](https://img.shields.io/badge/-70fc6b-70fc6b) | Relates to the example apps included in this repository. | Not all repositories have embedded example apps. |
+| `failing-test` | ![ff8888](https://img.shields.io/badge/-ff8888-ff8888) | Where a test is failing either locally or in CI. Perhaps flakey (badly written), wrong or bug. |
+| `testing` | ![ff8888](https://img.shields.io/badge/-ff8888-ff8888) | Includes all kinds of tests, the way that we run tests and test infrastructure. |
 
 While GitHub does allow us to use mixed case and spaces in label names, we've restricted ourselves to all lowercase and dashes instead of spaces to separate words.
 

--- a/sdk/github.md
+++ b/sdk/github.md
@@ -220,6 +220,8 @@ The following table canonically defines labels we use in common across our open 
 | `failing-test` | ![ff8888](https://img.shields.io/badge/-ff8888-ff8888) | Where a test is failing either locally or in CI. Perhaps flakey (badly written), wrong or bug. |
 | `testing` | ![ff8888](https://img.shields.io/badge/-ff8888-ff8888) | Includes all kinds of tests, the way that we run tests and test infrastructure. |
 
+The _Name_, _Color_ and _Description_ values above should be used when creating the corresponding labels in repositories.
+
 While GitHub does allow us to use mixed case and spaces in label names, we've restricted ourselves to all lowercase and dashes instead of spaces to separate words.
 
 We do not have any labels that imply or otherwise infer importance or prioritisation of issues or pull requests because that information is internally managed using Jira (see [GitHub First](#github-first)).

--- a/sdk/github.md
+++ b/sdk/github.md
@@ -212,7 +212,7 @@ The following table canonically defines labels we use in common across our open 
 | `blocked-by-ably` | ![fbca04](https://img.shields.io/badge/-fbca04-fbca04) | We can't proceed until something under our direct control, in a different codebase, happens. | Comments should be added to indicate what the blockage is (e.g. another SDK repository). |
 | `blocked-by-external` | ![fbca04](https://img.shields.io/badge/-fbca04-fbca04) | We can't proceed until something outside of Ably's direct control happens. | Comments should be added to indicate what the blockage is. |
 | `bug` | ![d73a4a](https://img.shields.io/badge/-d73a4a-d73a4a) | Something isn't working. It's clear that this does need to be fixed. | Usually implies that related changes can be released in a `patch` version bump. |
-| `breaking` | ![ec4b42](https://img.shields.io/badge/-ec4b42-ec4b42) | Affects the developer experience when working in our codebase. | Implies a need to release related changes in a `major` version bump. |
+| `breaking` | ![ec4b42](https://img.shields.io/badge/-ec4b42-ec4b42) | Backwards incompatible changes made to the public API. | Implies a need to release related changes in a `major` version bump. |
 | `code-quality` | ![ff88cc](https://img.shields.io/badge/-ff88cc-ff88cc) | Affects the developer experience when working in our codebase. |
 | `documentation` | ![0075ca](https://img.shields.io/badge/-0075ca-0075ca) | Improvements or additions to public interface documentation (API reference or readme). |
 | `enhancement` | ![a2eeef](https://img.shields.io/badge/-a2eeef-a2eeef) | New feature or request. | Implies a need to release related changes in a `minor` version bump. |

--- a/sdk/github.md
+++ b/sdk/github.md
@@ -217,7 +217,7 @@ The following table canonically defines labels we use in common across our open 
 | `documentation` | ![0075ca](https://img.shields.io/badge/-0075ca-0075ca) | Improvements or additions to public interface documentation (API reference or readme). |
 | `enhancement` | ![a2eeef](https://img.shields.io/badge/-a2eeef-a2eeef) | New feature or improved functionality. | Implies a need to release related changes in a `minor` version bump. |
 | `example-app` | ![70fc6b](https://img.shields.io/badge/-70fc6b-70fc6b) | Relates to the example apps included in this repository. | Not all repositories have embedded example apps. |
-| `failing-test` | ![ff8888](https://img.shields.io/badge/-ff8888-ff8888) | Where a test is failing either locally or in CI. Perhaps flakey (badly written), wrong or bug. |
+| `failing-test` | ![ff8888](https://img.shields.io/badge/-ff8888-ff8888) | Where a test is failing either locally or in CI. Perhaps flakey, wrong or bug. |
 | `testing` | ![ff8888](https://img.shields.io/badge/-ff8888-ff8888) | Includes all kinds of tests, the way that we run tests and test infrastructure. |
 
 The _Name_, _Color_ and _Description_ values above should be used when creating the corresponding labels in repositories.

--- a/sdk/github.md
+++ b/sdk/github.md
@@ -215,7 +215,7 @@ The following table canonically defines labels we use in common across our open 
 | `breaking` | ![ec4b42](https://img.shields.io/badge/-ec4b42-ec4b42) | Backwards incompatible changes made to the public API. | Implies a need to release related changes in a `major` version bump. |
 | `code-quality` | ![ff88cc](https://img.shields.io/badge/-ff88cc-ff88cc) | Affects the developer experience when working in our codebase. | Relating to the maintainabily of the codebase, not affecting the public API, therefore unlikely to be customer facing. |
 | `documentation` | ![0075ca](https://img.shields.io/badge/-0075ca-0075ca) | Improvements or additions to public interface documentation (API reference or readme). |
-| `enhancement` | ![a2eeef](https://img.shields.io/badge/-a2eeef-a2eeef) | New feature or request. | Implies a need to release related changes in a `minor` version bump. |
+| `enhancement` | ![a2eeef](https://img.shields.io/badge/-a2eeef-a2eeef) | New feature or improved functionality. | Implies a need to release related changes in a `minor` version bump. |
 | `example-app` | ![70fc6b](https://img.shields.io/badge/-70fc6b-70fc6b) | Relates to the example apps included in this repository. | Not all repositories have embedded example apps. |
 | `failing-test` | ![ff8888](https://img.shields.io/badge/-ff8888-ff8888) | Where a test is failing either locally or in CI. Perhaps flakey (badly written), wrong or bug. |
 | `testing` | ![ff8888](https://img.shields.io/badge/-ff8888-ff8888) | Includes all kinds of tests, the way that we run tests and test infrastructure. |


### PR DESCRIPTION
See [this Slack thread (internal)](https://ably-real-time.slack.com/archives/C03JDBVM5MY/p1665741282123009) for more context.

To speed things up for reviewers, while this pull request remains open, the rendered output from this change can be viewed on the underlying branch [here](https://github.com/ably/engineering/blob/sdk-github-labels/sdk/github.md#labels).