### PR TITLE
Add guidance around version bumps for SDK releases

### DIFF
--- a/sdk/github.md
+++ b/sdk/github.md
@@ -224,6 +224,9 @@ The _Name_, _Color_ and _Description_ values above should be used when creating 
 
 It is expected that some labels will be used together - for example `enhancement` and `breaking`, indicating a feature that's been added in a way that introduces backwards incompatible changes into the public API, therefore implying the need to release in a `major` (_not_ `minor`) version bump.
 
+The `breaking` and `enhancement` labels must be applied to all pull requests to which they apply (see: [Guidance on Releases: Version Bump](releases.md#version-bump)).
+They can also be applied to linked issues, but this is less important than labelling the change itself (i.e. the pull request).
+
 While GitHub does allow us to use mixed case and spaces in label names, we've restricted ourselves to all lowercase and dashes instead of spaces to separate words.
 
 We do not have any labels that imply or otherwise infer importance or prioritisation of issues or pull requests because that information is internally managed using Jira (see [GitHub First](#github-first)).

--- a/sdk/releases.md
+++ b/sdk/releases.md
@@ -61,13 +61,16 @@ For clarity, conforming to semantic versioning, here are example version updates
 | Increment 'build' numeric component of pre-release suffix | `2.0.0-rc.1` | `2.0.0-rc.2` | We want to remain in pre-release and our level of confidence remains the same, we've just iterated/improved. |
 | Remove pre-release suffix | `2.0.0-rc.2` | `2.0.0` | We're ready to move to GA for this release. | | Has implications for scope of changelog entry. See [this comment](https://github.com/ably/engineering/issues/17#issuecomment-1310626521). |
 
-See: [GitHub Standards and Best Practices: Labels](github.md#labels)
-
 "Trigger" analysis must include labels assigned to pull requests.
 It should also include labels assigned to issues linked to those pull requests.
 
 "Public API" only refers to the interfaces that users code against to use our SDKs.
 Therefore, SDK changes to the Ably REST or Realtime protocol implementation do not always necessitate a `major` version bump - that is, those changes may not need to be labelled `breaking`, unless they _also_ change the user-facing APIs offered by the SDK in a backwards incompatible manner.
+
+See also:
+
+- [GitHub Standards and Best Practices: Labels](github.md#labels)
+- [Guidance on Versioning](versioning.md)
 
 ## Version Tag
 

--- a/sdk/releases.md
+++ b/sdk/releases.md
@@ -67,7 +67,7 @@ See: [GitHub Standards and Best Practices: Labels](github.md#labels)
 It should also include labels assigned to issues linked to those pull requests.
 
 "Public API" only refers to the interfaces that users code against to use our SDKs.
-Therefore, SDK changes to the Ably REST or Realtime protocol implementation do not always necessitate a `major` version bump - that is, those changes may not need to be labelled `breaking`, unless they _also_ change the user-facing APIs offered by the SDK in an backwards incompatible manner.
+Therefore, SDK changes to the Ably REST or Realtime protocol implementation do not always necessitate a `major` version bump - that is, those changes may not need to be labelled `breaking`, unless they _also_ change the user-facing APIs offered by the SDK in a backwards incompatible manner.
 
 ## Version Tag
 

--- a/sdk/releases.md
+++ b/sdk/releases.md
@@ -25,7 +25,7 @@ Should:
 - branch from the `main` branch
 - merge to the `main` branch, once approved
 - be named like `release/<version>`
-- increment the version, conforming to [SemVer](https://semver.org/)
+- update the version - see [Version Bump](#version-bump)
 - add a change log entry (process to be documented under [#17](https://github.com/ably/engineering/issues/17))
 
 ## Publish Workflow
@@ -37,6 +37,37 @@ Should:
 - override the default [checkout](https://github.com/actions/checkout) `ref` with a commit SHA supplied as an input to the triggering event, where that SHA will generally be `HEAD` of the `main` branch, at the point the [Release Branch](#release-branch) was merged
 - publish to downstream package repositories using an Ably identity, not using an identity tied to an individual person in any way
 - use GitHub repository secrets or ideally [GitHub OIDC](https://docs.github.com/en/actions/deployment/security-hardening-your-deployments/about-security-hardening-with-openid-connect) (ask [@lmars](https://github.com/lmars)), to securely manage the flow of credentials required to publish under the Ably identity
+
+## Version Bump
+
+Should:
+
+- conform to [SemVer](https://semver.org/)
+- either:
+  - increment `major`, `minor`, `patch` or the nature of the pre-release suffix (see [Product Lifecycle](product-lifecycle.md)); or
+  - remove the pre-release suffix
+
+For clarity, conforming to semantic versioning, here are example version updates for each possible bump scenario:
+
+| Bump | Example Before | Example After | Trigger | SemVer Description | Notes |
+| ---- | -------------- | ------------- | ------- | ------------------ | ----- |
+| Increment `major` | `1.2.3` | `2.0.0` | Includes at least one change labelled `breaking` | [if any backwards incompatible changes are introduced to the public API](https://semver.org/#spec-item-8) | Users may need to change their code if they are using the affected APIs. |
+| Increment `minor` | `1.2.3` | `1.3.0` | Includes at least one change labelled `enhancement`, and no changes labelled `breaking` | [if new, backwards compatible functionality is introduced to the public API](https://semver.org/#spec-item-7) | Also include enhancements which don't change the public API but do add or improve functionality (e.g. performance improvement). |
+| Increment `patch` | `1.2.3` | `1.2.4` | Does not include any changes labelled either `enhancement` or `breaking` or both | [if only backwards compatible bug fixes are introduced](https://semver.org/#spec-item-6) |
+| Increment `major`, as pre-release | `1.2.3` | `2.0.0-rc.1` | Includes at least one change labelled `breaking` | [if any backwards incompatible changes are introduced to the public API](https://semver.org/#spec-item-8) | Users may need to change their code if they are using the affected APIs. |
+| Increment `minor`, as pre-release | `1.2.3` | `1.3.0-rc.1` | Includes at least one change labelled `enhancement`, and no changes labelled `breaking` | [if new, backwards compatible functionality is introduced to the public API](https://semver.org/#spec-item-7) | Also include enhancements which don't change the public API but do add or improve functionality (e.g. performance improvement). |
+| Increment `patch`, as pre-release | `1.2.3` | `1.2.4-rc.1` | Does not include any changes labelled either `enhancement` or `breaking` or both | [if only backwards compatible bug fixes are introduced](https://semver.org/#spec-item-6) |
+| Increment nature of pre-release suffix | `2.0.0-beta.2` | `2.0.0-rc.1` | We want to remain in pre-release, but our level of confidence has increased so we're upgrading the phase. |
+| Increment 'build' numeric component of pre-release suffix | `2.0.0-rc.1` | `2.0.0-rc.2` | We want to remain in pre-release and our level of confidence remains the same, we've just iterated/improved. |
+| Remove pre-release suffix | `2.0.0-rc.2` | `2.0.0` | We're ready to move to GA for this release. | | Has implications for scope of changelog entry. See [this comment](https://github.com/ably/engineering/issues/17#issuecomment-1310626521). |
+
+See: [GitHub Standards and Best Practices: Labels](github.md#labels)
+
+"Trigger" analysis must include labels assigned to pull requests.
+It should also include labels assigned to issues linked to those pull requests.
+
+"Public API" only refers to the interfaces that users code against to use our SDKs.
+Therefore, SDK changes to the Ably REST or Realtime protocol implementation do not always necessitate a `major` version bump - that is, those changes may not need to be labelled `breaking`, unless they _also_ change the user-facing APIs offered by the SDK in an backwards incompatible manner.
 
 ## Version Tag
 


### PR DESCRIPTION
Builds upon the work done in #44.

To speed things up for reviewers, while this pull request remains open, the rendered output from the primary change presented here can be viewed on the underlying branch [here](https://github.com/ably/engineering/blob/sdk-releases-version-bumps/sdk/releases.md#version-bump).

Related: https://github.com/ably/engineering/issues/17#issuecomment-1310626521