### PR TITLE
Sort GitHub labels

### DIFF
--- a/sdk/github.md
+++ b/sdk/github.md
@@ -211,8 +211,8 @@ The following table canonically defines labels we use in common across our open 
 | ---- | ----------- | ----- | ---------------- |
 | `blocked-by-ably` | ![fbca04](https://img.shields.io/badge/-fbca04-fbca04) | We can't proceed until something under our direct control, in a different codebase, happens. | Comments should be added to indicate what the blockage is (e.g. another SDK repository). |
 | `blocked-by-external` | ![fbca04](https://img.shields.io/badge/-fbca04-fbca04) | We can't proceed until something outside of Ably's direct control happens. | Comments should be added to indicate what the blockage is. |
-| `bug` | ![d73a4a](https://img.shields.io/badge/-d73a4a-d73a4a) | Something isn't working. It's clear that this does need to be fixed. | Usually implies that related changes can be released in a `patch` version bump. |
 | `breaking` | ![ec4b42](https://img.shields.io/badge/-ec4b42-ec4b42) | Backwards incompatible changes made to the public API. | Implies a need to release related changes in a `major` version bump. |
+| `bug` | ![d73a4a](https://img.shields.io/badge/-d73a4a-d73a4a) | Something isn't working. It's clear that this does need to be fixed. | Usually implies that related changes can be released in a `patch` version bump. |
 | `code-quality` | ![ff88cc](https://img.shields.io/badge/-ff88cc-ff88cc) | Affects the developer experience when working in our codebase. | Relating to the maintainabily of the codebase, not affecting the public API, therefore unlikely to be customer facing. |
 | `documentation` | ![0075ca](https://img.shields.io/badge/-0075ca-0075ca) | Improvements or additions to public interface documentation (API reference or readme). |
 | `enhancement` | ![a2eeef](https://img.shields.io/badge/-a2eeef-a2eeef) | New feature or improved functionality. | Implies a need to release related changes in a `minor` version bump. |


### PR DESCRIPTION
A minor thing I noticed when working on conforming labels across repositories, as I was cross-checking with this table.

While this pull request remains open you can view the result of this change on the underlying branch [here](https://github.com/ably/engineering/blob/sort-github-labels/sdk/github.md#labels).