### PR TITLE
Make it clearer that labels for testing relate to automated testing

### DIFF
--- a/sdk/github.md
+++ b/sdk/github.md
@@ -217,8 +217,8 @@ The following table canonically defines labels we use in common across our open 
 | `documentation` | ![0075ca](https://img.shields.io/badge/-0075ca-0075ca) | Improvements or additions to public interface documentation (API reference or readme). |
 | `enhancement` | ![a2eeef](https://img.shields.io/badge/-a2eeef-a2eeef) | New feature or improved functionality. | Implies a need to release related changes in a `minor` version bump. |
 | `example-app` | ![70fc6b](https://img.shields.io/badge/-70fc6b-70fc6b) | Relates to the example apps included in this repository. | Not all repositories have embedded example apps. |
-| `failing-test` | ![ff8888](https://img.shields.io/badge/-ff8888-ff8888) | Where a test is failing either locally or in CI. Perhaps flakey, wrong or bug. |
-| `testing` | ![ff8888](https://img.shields.io/badge/-ff8888-ff8888) | Includes all kinds of tests, the way that we run tests and test infrastructure. |
+| `failing-test` | ![ff8888](https://img.shields.io/badge/-ff8888-ff8888) | Where an automated test is failing either locally or in CI. Perhaps flakey, wrong or bug. |
+| `testing` | ![ff8888](https://img.shields.io/badge/-ff8888-ff8888) | Includes all kinds of automated tests, the way that we run them and the infrastructure around them. |
 
 The _Name_, _Color_ and _Description_ values above should be used when creating the corresponding labels in repositories.
 


### PR DESCRIPTION
This change is being made because of potential confusion when manual user testing is taking place. See [this Slack thread (internal)](https://ably-real-time.slack.com/archives/C01EPJENRD0/p1670351059673369).