### PR TITLE
recommend using workflow_dispatch by default

### DIFF
--- a/sdk/github.md
+++ b/sdk/github.md
@@ -164,6 +164,7 @@ Unless there a good reason to deviate from this, workflows should always be conf
 
 ```yml
 on:
+  workflow_dispatch:
   pull_request:
   push:
     branches:


### PR DESCRIPTION
Sometimes you need to trigger a CI run to check if the tests are still passing on the main branch (eg if you want to know if the tests have been affected by a change in server behaviour), this is especially useful if you don't have a dev environment set to run tests in the repo. Currently there are two main ways you can do this:
1. Open a PR with some trivial commit (hacky and time consuming)
2. Re-run tests on the main branch (only possible if the last test run was within the past 30 days, risks losing a green tick on the repo homepage)

It costs basically nothing to make these workflows manually triggerable and gives a much nicer solution to the aforementioned problem so I think we should recommend this by default.